### PR TITLE
[FIX] spec for content_available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 vendor
-.idea

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Or add this to your composer.json and run "composer update":
 }
 ```
 
-#Send message to Device
+#Send message to **one or multiple** Devices
 ```
 use sngrl\PhpFirebaseCloudMessaging\Client;
 use sngrl\PhpFirebaseCloudMessaging\Message;

--- a/src/Message.php
+++ b/src/Message.php
@@ -13,6 +13,7 @@ class Message implements \JsonSerializable
     private $notification;
     private $collapseKey;
     private $priority;
+    private $contentAvailable;
     private $data;
     private $recipients = [];
     private $recipientType;
@@ -59,6 +60,17 @@ class Message implements \JsonSerializable
     public function setPriority($priority)
     {
         $this->priority = $priority;
+        return $this;
+    }
+
+    public function getContentAvailable()
+    {
+        return $this->contentAvailable;
+    }
+
+    public function setContentAvailable($contentAvailable)
+    {
+        $this->contentAvailable = $contentAvailable;
         return $this;
     }
 
@@ -158,6 +170,9 @@ class Message implements \JsonSerializable
         }
         if ($this->priority) {
             $jsonData['priority'] = $this->priority;
+        }
+        if ($this->contentAvailable) {
+            $jsonData['content_available'] = $this->contentAvailable;
         }
         if ($this->notification) {
             $jsonData['notification'] = $this->notification;

--- a/src/Notification.php
+++ b/src/Notification.php
@@ -13,7 +13,6 @@ class Notification extends Message
     private $sound;
     private $clickAction;
     private $tag;
-    private $content_available;
 
     public function __construct($title = '', $body = '')
     {
@@ -78,12 +77,6 @@ class Notification extends Message
         return $this;
     }
 
-    public function setContentAvailable($content_available)
-    {
-        $this->content_available = $content_available;
-        return $this;
-    }
-
     public function jsonSerialize()
     {
         $jsonData = $this->getJsonData();
@@ -108,9 +101,6 @@ class Notification extends Message
         if ($this->tag) {
             $jsonData['tag'] = $this->tag;
         }
-        if ($this->content_available) {
-            $jsonData['content_available'] = $this->content_available;
-        }        
         return $jsonData;
     }
 }

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -68,4 +68,19 @@ class MessageTest extends PhpFirebaseCloudMessagingTestCase
             json_encode($message)
         );
     }
+
+    public function testJsonSerializeWithContentAvailable()
+    {
+        $body = '{"to":"deviceId","content_available":true,"notification":{"title":"test","body":"a nice testing notification"}}';
+
+        $notification = new Notification('test', 'a nice testing notification');
+        $message = new Message();
+        $message->setNotification($notification);
+        $message->setContentAvailable(true);
+        $message->addRecipient(new Device('deviceId'));
+        $this->assertSame(
+            $body,
+            json_encode($message)
+        );
+    }
 }

--- a/tests/NotificationTest.php
+++ b/tests/NotificationTest.php
@@ -29,10 +29,4 @@ class NotificationTest extends PhpFirebaseCloudMessagingTestCase
         $this->fixture->setIcon('name');
         $this->assertEquals(array('title' => 'foo', 'body' =>'bar', 'icon' => 'name'), $this->fixture->jsonSerialize());
     }
-
-    public function testJsonSerializeWithContentAvailable()
-    {
-        $this->fixture->setContentAvailable(true);
-        $this->assertEquals(array('title' => 'foo', 'body' =>'bar', 'content_available' => true), $this->fixture->jsonSerialize());
-    }
 }


### PR DESCRIPTION
The `content_available` parameter must be in the general payload, not in the notification payload.
[docs](https://firebase.google.com/docs/cloud-messaging/http-server-ref#content_available)

```json
{
 "notification": {
   "title": "Portugal vs. Denmark",
   "body": "5 to 1"
 },
 "content_available": true,
 "priority": "high",
 "to": "jfkezfz124"
}
```