### PR TITLE
Do not serialize notification object when it contains no serializable…

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -174,7 +174,7 @@ class Message implements \JsonSerializable
         if ($this->contentAvailable) {
             $jsonData['content_available'] = $this->contentAvailable;
         }
-        if ($this->notification) {
+        if ($this->notification && $this->notification->hasNotificationData()) {
             $jsonData['notification'] = $this->notification;
         }
 

--- a/src/Notification.php
+++ b/src/Notification.php
@@ -77,9 +77,14 @@ class Notification extends Message
         return $this;
     }
 
+    public function hasNotificationData()
+    {
+        return $this->title || $this->body || $this->badge || $this->icon || $this->clickAction || $this->sound || $this->tag;
+    }
+
     public function jsonSerialize()
     {
-        $jsonData = $this->getJsonData();
+        $jsonData = [];
         if ($this->title) {
             $jsonData['title'] = $this->title;
         }


### PR DESCRIPTION
Do not serialize notification object when it contains no serializable data. Since the notification payload part is optional it should be possible to leave it completely out. Unfortunately due to how `json_encode` combined with the `JsonSerializable` interface works the hasData call is our best shot to prevent a `notification` key being added to the root json object.